### PR TITLE
Improve handling of copy-paste

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1489,7 +1489,8 @@ process_char:
         }
 #endif
         switch(c) {
-        case '\r':    /* enter */
+        case '\n':    /* enter received while the console is busy */
+        case '\r':    /* enter received in raw mode while the console is ready */
             historyCritical_Enter();
             history_len--;
             free(history[history_len]);


### PR DESCRIPTION
When the terminal is waiting for keypresses, in raw mode, and the enter key is pressed,
it will receive an "\r". However if it's busy executing something else, then it will receive an "\n".
So if you try to copy-paste (or type) a multi-line command, while the terminal is busy, the newlines
will be ignored. This commit fixes that issue.

How to test 1):
in bash:
(echo a; echo b) | ./linenoise_example

This should results in a and b interpreted as different commands.

How to test 2):
add usleep(1000000) into the loop in example.c.
compile, and start up ./linenoise_example
Try to paste some multiline commands, and while those are being slowly pasted, try pasting another set of multiline commands.
If there is an issue the second set of multi-line commands will appear conatenated.